### PR TITLE
Enableling url field to be populated via URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <script type="text/javascript" src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js"></script>
     <script type="text/javascript" src="js/castplayer.js"></script>
     <script type="text/javascript" src="js/urlplayer.js"></script>
+    <script type="text/javascript" src="js/params.js"></script>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -21,7 +22,7 @@
       ga('send', 'pageview');
     </script>
   </head>
-  <body>
+  <body onload="onload()">
     <!-- top bar -->
     <div class="navbar navbar-default navbar-fixed-top">
       <div class="container">

--- a/js/params.js
+++ b/js/params.js
@@ -1,0 +1,17 @@
+function onload() {
+  var url = getUrlParameter("url")
+  if (url) {
+    $('#url').val(url);
+  }
+}
+
+function getUrlParameter(sParam) {
+    var sPageURL = window.location.search.substring(1);
+    var sURLVariables = sPageURL.split('&');
+    for (var i = 0; i < sURLVariables.length; i++)  {
+        var sParameterName = sURLVariables[i].split('=');
+        if (sParameterName[0] == sParam) {
+            return decodeURIComponent(sParameterName[1]);
+        }
+    }
+}


### PR DESCRIPTION
First thanks for creating a great site :)
This change enables client to set the url input field via an URL argument 'url'.
I am fiddling hobby project where i get a video URL from a REST API. I would like to sent it through your service to my Chromecast, so I need a way to provide the URL. 
I hope you can accept this request. 
-Tobias
