### PR TITLE
Use protocol-relative link for fonts.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="css/bootstrap.css" />
     <link rel="stylesheet" href="css/bootswatch.min.css" />
     <link href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" rel="stylesheet">
-    <link href='http://fonts.googleapis.com/css?family=Jura:600' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Jura:600' rel='stylesheet' type='text/css'>
     <script type="text/javascript" src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js"></script>
     <script type="text/javascript" src="js/castplayer.js"></script>
     <script type="text/javascript" src="js/urlplayer.js"></script>


### PR DESCRIPTION
This fixes the mixed-content warning that you get when hosting the URL player over HTTPS.
