### PR TITLE
add OGG and AAC

### DIFF
--- a/js/urlplayer.js
+++ b/js/urlplayer.js
@@ -33,6 +33,8 @@ function getContentType(url) {
     {ext: 'mp4', type: 'video'},
     {ext: 'm4v', type: 'video'},
     {ext: 'm4a', type: 'audio'},
+    {ext: 'ogg', type: 'audio'},
+    {ext: 'aac', type: 'audio'},
     {ext: 'jpeg', type: 'image'},
     {ext: 'jpg', type: 'image'},
     {ext: 'gif', type: 'image'},


### PR DESCRIPTION
The streaming radio stations I use are typically AAC or OGG, and as these work with my Chromecast, no reason to leave them out.